### PR TITLE
Support triggering sync from Dispatch

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,12 @@
 name: Sync
 
 on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'Filter sync for a specific repository (exact name or regex)'
+        required: false
+        default: ''
   push:
     branches:
       - master
@@ -29,4 +35,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MODULESYNC_TOKEN }}
         run: |
           sha="$(git rev-parse --short HEAD)"
-          bundle exec msync update --pr --pr-title "[ModuleSync] Update from ${{ github.repository }}@${sha}" --remote-branch "modulesync-${sha}"
+          msync_args="--filter=${{ github.event.inputs.filter }}"
+          bundle exec msync update --pr --pr-title "[ModuleSync] Update from ${{ github.repository }}@${sha}" --remote-branch "modulesync-${sha}" ${msync_args}

--- a/README.adoc
+++ b/README.adoc
@@ -2,3 +2,8 @@
 
 ModuleSync configuration and template repository for Commodore components.
 This repository will manage the CI/CD scaffolding for several Commodore components.
+
+== Triggering a sync
+
+- Via commit to master
+- Via Workflow Dispatch (https://github.com/projectsyn/modulesync-control/actions/workflows/sync.yml)


### PR DESCRIPTION
Allows to trigger the sync via Dispatch. On GitHub WebUI, that would in https://github.com/projectsyn/modulesync-control/actions/workflows/sync.yml. Optionally, it accepts a filter where the sync would only sync the repository(s) matching the regex.