### PR TITLE
Add local dependencies search path in commodore test compile

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -51,6 +51,7 @@ docs-serve: ## Preview the documentation
 
 .PHONY: compile
 .compile:
+	mkdir -p dependencies
 	$(COMMODORE_CMD)
 
 .PHONY: test

--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -54,7 +54,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml
+test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
 test: .compile ## Compile the component
 
 .PHONY: clean


### PR DESCRIPTION
See also / same as projectsyn/commodore/pull/349.

Currently the `parameters.kapitan.dependencies.[].output_path` needs to be overridden for all dependencies in test compiles (`make test`).

See:
- https://github.com/projectsyn/component-cert-manager/blob/master/tests/defaults.yml#L9
- https://github.com/projectsyn/component-keycloak/blob/master/tests/builtin.yml#L10
- https://github.com/projectsyn/component-keycloak/blob/master/tests/external.yml#L10

This is not optimal. It can lead to errors if a developer forgets to update the `tests/` file. The "real" output can now differ from the test output. Additionally it won't scale for components like [`component-argocd`](https://github.com/projectsyn/component-argocd/blob/master/class/argocd.yml) where there are many dependecies.

This PR adds the local directory `./dependencies` to the search path, which allows tests to run without overriding the output path.

<details>
  <summary>Example: `component-cert-manager`</summary>
  
```diff
diff --git a/Makefile b/Makefile
index 59972dd..b76fb8e 100644
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml
+test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
 test: .compile ## Compile the component
 
 .PHONY: clean
diff --git a/tests/defaults.yml b/tests/defaults.yml
index 8971146..739347e 100644
--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,12 +1,3 @@
 parameters:
-  kapitan:
-    dependencies:
-      - type: helm
-        source: https://charts.jetstack.io
-        chart_name: cert-manager
-        version: ${cert_manager:charts:cert-manager}
-        # This is the required overrride
-        output_path: /cert-manager/helmcharts/cert-manager/${cert_manager:charts:cert-manager}/
-
   cert_manager:
     letsencrypt_email: test@syn.tools
```
</details>
