### PR TITLE
Exclude jsonnet files from indent linter

### DIFF
--- a/moduleroot/.editorconfig.erb
+++ b/moduleroot/.editorconfig.erb
@@ -14,7 +14,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{y*ml,*json*,*sonnet}]
+[*.{y*ml,*json}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
See: https://github.com/projectsyn/commodore/pull/360

`jsonnetfmt` already has a very opinionated formatter, which makes the linter superfluous and can lead to conflicts between `jsonnetfmt` and `editorconfig` linters.

See: https://github.com/projectsyn/component-backup-k8up/pull/36/checks?check_run_id=3221663321#step:3:10



## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
