### PR TITLE
Make yamllint exludes work on both BSD and GNU

### DIFF
--- a/moduleroot/.yamllint.yml.erb
+++ b/moduleroot/.yamllint.yml.erb
@@ -9,3 +9,10 @@ rules:
   line-length:
     max: 80
     level: warning
+
+ignore: |
+  dependencies/
+  helmcharts/
+  manifests/
+  vendor/
+  compiled/

--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -31,8 +31,8 @@ lint_jsonnet: $(JSONNET_FILES) ## Lint jsonnet files
 	$(JSONNET_DOCKER) $(JSONNETFMT_ARGS) --test -- $?
 
 .PHONY: lint_yaml
-lint_yaml: $(YAML_FILES) ## Lint yaml files
-	$(YAMLLINT_DOCKER) -f parsable -c $(YAMLLINT_CONFIG) $(YAMLLINT_ARGS) -- $?
+lint_yaml: ## Lint yaml files
+	$(YAMLLINT_DOCKER) -f parsable -c $(YAMLLINT_CONFIG) $(YAMLLINT_ARGS) -- .
 
 .PHONY: lint_adoc
 lint_adoc: ## Lint documentation

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -19,7 +19,6 @@ JSONNETFMT_ARGS ?= --in-place --pad-arrays
 JSONNET_IMAGE   ?= docker.io/bitnami/jsonnet:latest
 JSONNET_DOCKER  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=jsonnetfmt $(JSONNET_IMAGE)
 
-YAML_FILES      ?= $(shell find . -type f -not -regex './\(helmcharts\|manifests\|vendor\)/.*' \( -name '*.yaml' -or -name '*.yml' \))
 YAMLLINT_ARGS   ?= --no-warnings
 YAMLLINT_CONFIG ?= .yamllint.yml
 YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest


### PR DESCRIPTION
`find` works differently on GNU and BSD.

BSD find would need an `-E` option or have the backslash before the braces removed.

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
