### PR TITLE
Fix gen-golden: Copy content instead of directory

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -69,7 +69,7 @@ gen-golden: commodore_args = -f tests/$(instance).yml --search-paths ./dependenc
 gen-golden: .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
-	@cp -r compiled/* tests/golden/$(instance)
+	@cp -R compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
 golden-diff: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies


### PR DESCRIPTION

## Checklist

- [ ] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
