### PR TITLE
Validate Kubernetes objects using `kubeval`

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -2,6 +2,7 @@
   feature_componentCompile: true
   feature_goUnitTests: false
   feature_goldenTests: false
+  feature_kubevalValidate: false
   componentName: ""
 
 .github/ISSUE_TEMPLATE/config.yml:

--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -82,3 +82,24 @@ jobs:
       - name: Golden diff
         run: make golden-diff
 <%- end -%>
+<%- if @configs['feature_kubevalValidate'] -%>
+  validate:
+    runs-on: ubuntu-latest
+  <%- if !@configs['matrix'].empty? -%>
+    strategy:
+      matrix:
+        <%= @configs['matrix']['key'] -%>:
+<% @configs['matrix']['entries'].each do |entry| -%>
+          - <%= entry %>
+<% end -%>
+  <%- end -%>
+    defaults:
+      run:
+        working-directory: ${{ env.COMPONENT_NAME }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.COMPONENT_NAME }}
+      - name: Validate Kubernetes objects
+        run: make validate
+<%- end -%>

--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -76,6 +76,15 @@ golden-diff: commodore_args = -f tests/$(instance).yml --search-paths ./dependen
 golden-diff: .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 <%- end -%>
+<%- if @configs['feature_kubevalValidate'] -%>
+
+.PHONY: validate
+validate: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
+validate: .compile ## Validate the resulting Kubernetes objects using kubeval.
+	@echo
+	@echo
+	$(KUBEVAL_DOCKER) $(KUBEVAL_ARGS) -d compiled/
+<%- end -%>
 
 .PHONY: clean
 clean: ## Clean the project

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -25,7 +25,7 @@ YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest
 YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(YAMLLINT_IMAGE)
 <%- if @configs['feature_kubevalValidate'] -%>
 
-KUBEVAL_ARGS   ?= --ignore-missing-schemas
+KUBEVAL_ARGS   ?= --ignore-missing-schemas --strict
 KUBEVAL_IMAGE  ?= docker.io/cytopia/kubeval:latest
 KUBEVAL_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(KUBEVAL_IMAGE)
 <%- end -%>

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -23,6 +23,12 @@ YAMLLINT_ARGS   ?= --no-warnings
 YAMLLINT_CONFIG ?= .yamllint.yml
 YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest
 YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(YAMLLINT_IMAGE)
+<%- if @configs['feature_kubevalValidate'] -%>
+
+KUBEVAL_ARGS   ?= --ignore-missing-schemas
+KUBEVAL_IMAGE  ?= docker.io/cytopia/kubeval:latest
+KUBEVAL_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(KUBEVAL_IMAGE)
+<%- end -%>
 
 VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --volume "$${PWD}"/docs/modules:/pages vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages


### PR DESCRIPTION
This PR adds a `validate` target for both the `Makefile` and the Github test action. The action is used to validate the compiled Kubernetes config.

We already use `kubeval` in some components, this PR aims at creating a standardised way to use it:
https://github.com/projectsyn/component-lieutenant/blob/efa4020cf71a761de81a601da781ae0af459c396/tests/unit/defaults_test.go#L72

See https://github.com/projectsyn/component-kyverno/pull/16 for a sample of the changes.


## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
