### PR TITLE
Update compile make targets to support components with library

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -55,7 +55,7 @@ docs-serve: ## Preview the documentation
 	$(COMMODORE_CMD)
 
 .PHONY: test
-test: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
+test: commodore_args += -f tests/$(instance).yml
 test: .compile ## Compile the component
 <%- if @configs['feature_goUnitTests'] -%>
 	@echo
@@ -65,14 +65,14 @@ test: .compile ## Compile the component
 <%- if @configs['feature_goldenTests'] -%>
 
 .PHONY: gen-golden
-gen-golden: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
+gen-golden: commodore_args += -f tests/$(instance).yml
 gen-golden: .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
 	@cp -R compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
-golden-diff: commodore_args = -f tests/$(instance).yml --search-paths ./dependencies
+golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 <%- end -%>

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -10,6 +10,7 @@ COMPONENT_NAME ?= $(shell basename ${PWD} | sed s/component-//)
 compiled_path   ?= compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)
 root_volume     ?= -v "$${PWD}:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
+commodore_args  ?= --search-paths ./dependencies --search-paths .
 
 DOCKER_CMD   ?= docker
 DOCKER_ARGS  ?= run --rm -u "$$(id -u)" -w /$(COMPONENT_NAME)


### PR DESCRIPTION
When compiling a component which makes use of its own component library, we need to add the component directory to the search paths for `commodore component compile`.

This commit sets the default value of variable `commodore_args` to

```
--search-paths ./dependencies --search-paths .
````

This variable is used by all compile targets, and some targets now append `-f tests/$(instance).yml` to the variable instead of setting the variable from scratch.

Matching commodore PR: https://github.com/projectsyn/commodore/pull/368

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
