### PR TITLE
Enable matrix operations on goldenTests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -12,6 +12,7 @@
 
 .github/workflows/test.yaml:
   makeTarget: test
+  goldenTest_makeTarget: golden-diff # Requires `feature_goldenTests`
   matrix: {}
   # key: provider
   # entries:

--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -80,5 +80,5 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Golden diff
-        run: make golden-diff
+        run: make <%= @configs['goldenTest_makeTarget'] %>
 <%- end -%>


### PR DESCRIPTION
See https://github.com/appuio/component-group-sync-operator/pull/6

## Checklist

- [ ] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
