### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
 ## Checklist
 
 - [ ] The [component template][commodore] has a PR open that syncs the changes with this one.
-- [ ] Keep pull requests small so they can be easily reviewed.
 - [ ] Categorize the PR by setting a good title and adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
       as they show up in the changelog

--- a/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
+++ b/moduleroot/.github/PULL_REQUEST_TEMPLATE.md.erb
@@ -1,23 +1,22 @@
-<!--
-Thank you for your pull request. Please provide a description above and
-review the checklist below.
 
-Contributors guide: ./CONTRIBUTING.md
--->
+
 
 ## Checklist
-<!--
-Remove items that do not apply. For completed items, change [ ] to [x].
--->
 
-- [ ] Keep pull requests small so they can be easily reviewed.
+- [ ] PR contains a single logical change (to build a better changelog).
 - [ ] Update the documentation.
 - [ ] Categorize the PR by setting a good title and adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
-      as they show up in the changelog
-- [ ] Link this PR to related issues.
+      as they show up in the changelog.
+- [ ] Link this PR to related issues or PRs.
 
 <!--
-NOTE: these things are not required to open a PR and can be done afterwards,
+Thank you for your pull request. Please provide a description above and
+review the checklist.
+
+Contributors guide: ./CONTRIBUTING.md
+
+Remove items that do not apply. For completed items, change [ ] to [x].
+These things are not required to open a PR and can be done afterwards,
 while the PR is open.
 -->


### PR DESCRIPTION
Related PR in commodore: https://github.com/projectsyn/commodore/pull/382

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
