### PR TITLE
Clean compiled artifacts before generating golden files

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -66,14 +66,14 @@ test: .compile ## Compile the component
 
 .PHONY: gen-golden
 gen-golden: commodore_args += -f tests/$(instance).yml
-gen-golden: .compile ## Update the reference version for target `golden-diff`.
+gen-golden: clean .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
 	@cp -R compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
 golden-diff: commodore_args += -f tests/$(instance).yml
-golden-diff: .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
+golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 <%- end -%>
 


### PR DESCRIPTION
If there are components that have matrix builds/instances, switching between instances could include undesired compiled artifacts. Thus we clean it before

(e.g. `make gen-golden -e instance=builtin` then `make gen-golden -e instance=external` `tests/golden/external` would also include the `builtin` files)

Commodore template update integrated in PR: https://github.com/projectsyn/commodore/pull/382

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
