### PR TITLE
Disable Renovate dashboard

### DIFF
--- a/moduleroot/renovate.json.erb
+++ b/moduleroot/renovate.json.erb
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff",
+    ":disableDependencyDashboard"
   ],
   "labels": [
     "dependency"


### PR DESCRIPTION
* Disable Renovate dependency dashboard for all components
* See also https://github.com/projectsyn/commodore/pull/387

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
