### PR TITLE
Ensure files are generated with the correct GID

### DIFF
--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -13,7 +13,7 @@ compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
 commodore_args  ?= --search-paths ./dependencies --search-paths .
 
 DOCKER_CMD   ?= docker
-DOCKER_ARGS  ?= run --rm -u "$$(id -u)" -w /$(COMPONENT_NAME)
+DOCKER_ARGS  ?= run --rm -u "$$(id -u):$$(id -g)" -w /$(COMPONENT_NAME)
 
 JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
 JSONNETFMT_ARGS ?= --in-place --pad-arrays


### PR DESCRIPTION
By default the GID defined in commodore's Dockerfile is used,
which may
or may not match an existing user on the system.

This commit explicitly sets the group ID when starting
containers.


## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one: projectsyn/commodore#397
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
