### PR TITLE
Explicitly set `HOME` environment variable for Commodore container

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -79,4 +79,4 @@ golden-diff: clean .compile ## Diff compile output against the reference version
 
 .PHONY: clean
 clean: ## Clean the project
-	rm -rf compiled dependencies vendor helmcharts jsonnetfile*.json || true
+	rm -rf .cache compiled dependencies vendor helmcharts jsonnetfile*.json || true

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -13,7 +13,7 @@ compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
 commodore_args  ?= --search-paths ./dependencies --search-paths .
 
 DOCKER_CMD   ?= docker
-DOCKER_ARGS  ?= run --rm -u "$$(id -u):$$(id -g)" -w /$(COMPONENT_NAME)
+DOCKER_ARGS  ?= run --rm -u "$$(id -u):$$(id -g)" -w /$(COMPONENT_NAME) -e HOME="/$(COMPONENT_NAME)"
 
 JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
 JSONNETFMT_ARGS ?= --in-place --pad-arrays


### PR DESCRIPTION
This fixes the issues introduced by #54 in `make test` for components which try to download a Helm chart. With the GID change for the container in #54, Commodore can't download files to `/app` anymore (the default home directory of the container), since that directory is owned by root.

This commit ensures that the Commodore container has a writable home directory by explicitly setting `HOME` to the component source directory.

See https://github.com/projectsyn/component-azuredisk-csi-driver/pull/26 for an example where the change breaks `make test`.

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one. https://github.com/projectsyn/commodore/pull/397
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
