### PR TITLE
Add a "real" make target for `compiled`

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -49,13 +49,15 @@ format_jsonnet: $(JSONNET_FILES) ## Format jsonnet files
 docs-serve: ## Preview the documentation
 	$(ANTORA_PREVIEW_CMD)
 
-.PHONY: compile
-.compile:
+compiled: commodore_args += -f tests/$(instance).yml
+compiled: class/defaults.yml class/$(component).yml tests/$(instance).yml $(JSONNET_FILES)
 	mkdir -p dependencies
 	$(COMMODORE_CMD)
 
+.PHONY: compile
+.compile: compiled
+
 .PHONY: test
-test: commodore_args += -f tests/$(instance).yml
 test: .compile ## Compile the component
 <%- if @configs['feature_goUnitTests'] -%>
 	@echo
@@ -65,14 +67,12 @@ test: .compile ## Compile the component
 <%- if @configs['feature_goldenTests'] -%>
 
 .PHONY: gen-golden
-gen-golden: commodore_args += -f tests/$(instance).yml
 gen-golden: clean .compile ## Update the reference version for target `golden-diff`.
 	@rm -rf tests/golden/$(instance)
 	@mkdir -p tests/golden/$(instance)
 	@cp -R compiled/. tests/golden/$(instance)/.
 
 .PHONY: golden-diff
-golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
 <%- end -%>

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -15,7 +15,7 @@ commodore_args  ?= --search-paths ./dependencies --search-paths .
 DOCKER_CMD   ?= docker
 DOCKER_ARGS  ?= run --rm -u "$$(id -u):$$(id -g)" -w /$(COMPONENT_NAME) -e HOME="/$(COMPONENT_NAME)"
 
-JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
+JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' -or -name '*.libjsonnet' \))
 JSONNETFMT_ARGS ?= --in-place --pad-arrays
 JSONNET_IMAGE   ?= docker.io/bitnami/jsonnet:latest
 JSONNET_DOCKER  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=jsonnetfmt $(JSONNET_IMAGE)


### PR DESCRIPTION
This allows us to actually leverage make's smart rebuilding for targets which need the compiled component (tests/golden files/...).

While this is not providing a big benefit for many components as we mainly use the targets based on `.compile` when making changes to the component implementation, there are some cases (e.g. rendering documentation from compiled manifests) where we save some time by reusing the compiled component manifests if no inputs have changed. 

Note that we keep the phony `.compile` target, so that components which have custom make rules which depend on that target continue to work unchanged.

## Checklist

- [ ] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
