### PR TITLE
Adjust the Antora docs preview command

### DIFF
--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -28,7 +28,7 @@ YAMLLINT_DOCKER ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) $(YAMLLINT_IMAGE)
 VALE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --volume "$${PWD}"/docs/modules:/pages docker.io/vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/antora docker.io/vshn/antora-preview:2.3.3 --style=syn --antora=docs
+ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}/.git":/antora/.git --volume "${PWD}/docs":/antora/docs docker.io/vshn/antora-preview:3.0.0.1 --style=syn --antora=docs
 
 COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install


### PR DESCRIPTION
The make target is still called `docs-serve`.

This PR:
* Bumps Antora preview command docker image to vshn/antora-preview:3.0.0.1.   This gives us a Antora preview which auto-refreshes the docs while the command is running and updates the image to one which contains the current VSHN Kroki instance URL.
* Only mounts `<component-dir>/docs` and `<component-dir>/.git` into the Docker container. This should avoid issues with Antora getting confused about paths in `vendor` not being readable in the container.
* Exposes port 35729 of the Docker container for the auto-reload browser plugin.



## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one. (https://github.com/projectsyn/commodore/pull/408)
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
