### PR TITLE
Add logic to generate Renovate `postUpgradeTasks`

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,6 +3,11 @@
   feature_goUnitTests: false
   feature_goldenTests: false
   componentName: ""
+  testMatrix: {}
+  # key: provider
+  # entries:
+  #   - variant1
+  #   - variant2
 
 .github/ISSUE_TEMPLATE/config.yml:
   contact_links:
@@ -13,11 +18,7 @@
 .github/workflows/test.yaml:
   makeTarget: test
   goldenTest_makeTarget: golden-diff # Requires `feature_goldenTests`
-  matrix: {}
-  # key: provider
-  # entries:
-  #   - variant1
-  #   - variant2
+  #matrix: {} # deprecated, use global param `testMatrix`
 
 docs/antora.yml:
   version: master

--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -1,3 +1,6 @@
+<%-
+@matrix = @configs.key?('matrix') ? @configs['matrix'] : @configs['testMatrix']
+-%>
 name: Pull Request
 on:
   pull_request:
@@ -30,11 +33,11 @@ jobs:
 <%- if @configs['feature_componentCompile'] -%>
   test:
     runs-on: ubuntu-latest
-  <%- if !@configs['matrix'].empty? -%>
+  <%- if !@matrix.empty? -%>
     strategy:
       matrix:
-        <%= @configs['matrix']['key'] -%>:
-<% @configs['matrix']['entries'].each do |entry| -%>
+        <%= @matrix['key'] -%>:
+<% @matrix['entries'].each do |entry| -%>
           - <%= entry %>
 <% end -%>
   <%- end -%>
@@ -64,11 +67,11 @@ jobs:
 <%- if @configs['feature_goldenTests'] -%>
   golden:
     runs-on: ubuntu-latest
-  <%- if !@configs['matrix'].empty? -%>
+  <%- if !@matrix.empty? -%>
     strategy:
       matrix:
-        <%= @configs['matrix']['key'] -%>:
-<% @configs['matrix']['entries'].each do |entry| -%>
+        <%= @matrix['key'] -%>:
+<% @matrix['entries'].each do |entry| -%>
           - <%= entry %>
 <% end -%>
   <%- end -%>

--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -75,6 +75,20 @@ gen-golden: clean .compile ## Update the reference version for target `golden-di
 golden-diff: commodore_args += -f tests/$(instance).yml
 golden-diff: clean .compile ## Diff compile output against the reference version. Review output and run `make gen-golden golden-diff` if this target fails.
 	@git diff --exit-code --minimal --no-index -- tests/golden/$(instance) compiled/
+<%- if !@configs['testMatrix'].empty? && !@configs['testMatrix']['entries'].empty? -%>
+
+.PHONY: golden-diff-all
+golden-diff-all: recursive_target=golden-diff
+golden-diff-all: $(test_instances) ## Run golden-diff for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: gen-golden-all
+gen-golden-all: recursive_target=gen-golden
+gen-golden-all: $(test_instances) ## Run gen-golden for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: $(test_instances)
+$(test_instances):
+	$(MAKE) $(recursive_target) -e instance=$(basename $(@F))
+<%- end -%>
 <%- end -%>
 
 .PHONY: clean

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -34,3 +34,6 @@ COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projects
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
 instance ?= defaults
+<%- if @configs['feature_goldenTests'] && !@configs['testMatrix'].empty? && !@configs['testMatrix']['entries'].empty? -%>
+test_instances =<%- @configs['testMatrix']['entries'].each do |entry| %> tests/<%= entry %>.yml<% end %>
+<%- end -%>

--- a/moduleroot/renovate.json.erb
+++ b/moduleroot/renovate.json.erb
@@ -4,6 +4,20 @@
     ":gitSignOff",
     ":disableDependencyDashboard"
   ],
+<%- if @configs['feature_goldenTests'] -%>
+  "postUpgradeTasks": {
+    "commands": [
+      <%- if !@configs['testMatrix'].empty? && !@configs['testMatrix']['entries'].empty? -%>
+      "make gen-golden-all"
+      <%- else -%>
+      "make gen-golden"
+      <%- end -%>
+    ],
+    "fileFilters": [ "tests/golden/**" ],
+    "executionMode": "update"
+  },
+  "suppressNotifications": [ "artifactErrors" ],
+<%- end -%>
   "labels": [
     "dependency"
   ]


### PR DESCRIPTION
Until now, the test matrix has been defined in a local variable for the `.github/workflows/test.yaml` template. To allow us to generate Renovate `postUpgradeTasks` and a list of test instances in a make variable, we need to be able to access the matrix test configuration in other templates.

This PR moves the test matrix configuration to global variable `testMatrix`. For now, the GitHub actions template will continue to read the test matrix from the file-level variable `matrix`, but will fall back to the global variable `testMatrix` if the file-level variable is missing.

Additionally, the PR adds new make targets `golden-diff-all` and `gen-golden-all`. These targets use a static list of test instances in make variable `test_instances`. The contents of this variable are generated from the modulesync parameter `testMatrix.entries`.

We use a generic recursive make target based on the `test_instances` make variable to implement the new targets. This allows us to reuse the existing `golden-diff` and `gen-golden` targets.

The new targets are only added for components which have matrix tests configured and which have migrated their matrix test configuration to modulesync parameter `testMatrix`.

Finally, this PR adds logic to generate section `postUpgradeTasks` in `renovate.json` for components
which have golden tests enabled. To determine the command to execute, we check if the component has matrix tests configured (based on parameter `testMatrix`). We use the `make gen-golden-all` as the command for components with matrix tests and `make gen-golden` for other components.

Commodore component-template PR: https://github.com/projectsyn/commodore/pull/424


## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
