### PR TITLE
Explicitly set `GITHUB_BASE_URL` for modulesync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Run modulesync
         env:
           GITHUB_TOKEN: ${{ secrets.MODULESYNC_TOKEN }}
+          GITHUB_BASE_URL: "https://api.github.com"
         run: |
           sha="$(git rev-parse --short HEAD)"
           msync_args="--filter=${{ github.event.inputs.filter }}"


### PR DESCRIPTION
This should fix the modulesync errors that are popping up for recent runs, e.g. https://github.com/projectsyn/modulesync-control/runs/5630431030?check_suite_focus=true

See the modulesync issue at https://github.com/voxpupuli/modulesync/issues/250



## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
