### PR TITLE
Update `actions/checkout` to v3 in component template

### DIFF
--- a/moduleroot/.github/workflows/release.yaml.erb
+++ b/moduleroot/.github/workflows/release.yaml.erb
@@ -8,7 +8,7 @@ jobs:
   dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
       - name: Build changelog from PRs with labels

--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -20,13 +20,13 @@ jobs:
           - lint_yaml
           - lint_adoc
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run ${{ matrix.command }}
         run: make ${{ matrix.command }}
   editorconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: snow-actions/eclint@v1.0.1
         with:
           args: 'check'
@@ -45,7 +45,7 @@ jobs:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ${{ env.COMPONENT_NAME }}
   <%- if @configs['feature_goUnitTests'] -%>
@@ -79,7 +79,7 @@ jobs:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Golden diff


### PR DESCRIPTION
Already updated in Commodore template in https://github.com/projectsyn/commodore/pull/420
## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
