### PR TITLE
Update GitHub actions `setup-go` and `cache` to v3 in template

### DIFF
--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -51,10 +51,10 @@ jobs:
   <%- if @configs['feature_goUnitTests'] -%>
       - name: Determine Go version from go.mod
         run: echo "GO_VERSION=$(grep "go 1." tests/go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Note: Go tests for components are not part of the Commodore component template.

## Checklist

- [ ] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
