### PR TITLE
Remove support for old `matrix` parameter in GitHub actions template

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -18,7 +18,6 @@
 .github/workflows/test.yaml:
   makeTarget: test
   goldenTest_makeTarget: golden-diff # Requires `feature_goldenTests`
-  #matrix: {} # deprecated, use global param `testMatrix`
 
 docs/antora.yml:
   version: master

--- a/moduleroot/.github/workflows/test.yaml.erb
+++ b/moduleroot/.github/workflows/test.yaml.erb
@@ -1,5 +1,5 @@
 <%-
-@matrix = @configs.key?('matrix') ? @configs['matrix'] : @configs['testMatrix']
+@matrix = @configs['testMatrix']
 -%>
 name: Pull Request
 on:


### PR DESCRIPTION
All onboarded components have been migrated to the new global parameter `testMatrix`.

Follow-up to #62 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
