### PR TITLE
Split `COMMODORE_CMD` and `COMPILE_CMD`

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -52,7 +52,7 @@ docs-serve: ## Preview the documentation
 .PHONY: compile
 .compile:
 	mkdir -p dependencies
-	$(COMMODORE_CMD)
+	$(COMPILE_CMD)
 
 .PHONY: test
 test: commodore_args += -f tests/$(instance).yml

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -36,7 +36,8 @@ VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages
 
 ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}/.git":/preview/antora/.git --volume "${PWD}/docs":/preview/antora/docs docker.io/vshn/antora-preview:3.0.1.1 --style=syn --antora=docs
 
-COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest component compile . $(commodore_args)
+COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projectsyn/commodore:latest
+COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
 instance ?= defaults


### PR DESCRIPTION
We want to be able to adjust which `commodore` to use without having to reproduce the full compile command when compiling individual components with `make test`, `make golden-diff` or `make gen-golden`.

This commit reduces `COMMODORE_CMD` to be the equivalent of a bare invocation of `commodore` and introduces a new variable `COMPILE_COMMAND` which corresponds to the previous value of `COMMODORE_CMD`.



Matching component-template PR: https://github.com/projectsyn/commodore/pull/437

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
