### PR TITLE
Remove component-azuredisk-csi-driver

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -1,7 +1,6 @@
 - component-acme-dns
 - component-adhoc-configurations
 - component-argocd
-- component-azuredisk-csi-driver
 - component-backup-k8up
 - component-cert-manager
 - component-cilium


### PR DESCRIPTION
Since AKS Kubernetes 1.21 the CSI driver is installed
via server side apply ba Azure itself.

No need anymore for this component.
