### PR TITLE
Bump release-changelog-builder-action to v3 in template

### DIFF
--- a/moduleroot/.github/workflows/release.yaml.erb
+++ b/moduleroot/.github/workflows/release.yaml.erb
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: "0"
       - name: Build changelog from PRs with labels
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v2
+        uses: mikepenz/release-changelog-builder-action@v3
         with:
           configuration: ".github/changelog-configuration.json"
           # PreReleases still get a changelog, but the next full release gets a diff since the last full release,


### PR DESCRIPTION

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one. https://github.com/projectsyn/commodore/pull/490
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
