### PR TITLE
Fix `.gitignore` entries

### DIFF
--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -5,17 +5,17 @@
 #
 
 # Commodore
-.cache/
-helmcharts/
-manifests/
-vendor/
-jsonnetfile.lock.json
-crds/
-compiled/
+/.cache
+/helmcharts
+/manifests
+/vendor
+/jsonnetfile.lock.json
+/crds
+/compiled
 
 # Antora
-_archive/
-_public/
+/_archive
+/_public
 
 # Additional entries
 <% @configs['additionalEntries'].each do |entry| -%>


### PR DESCRIPTION
We only want to ignore the directories created by Commodore in the component root. With the current `.gitignore`, we may accidentally ignore folders in the golden test output, or elsewhere.

Fixes #77

Commodore PR: https://github.com/projectsyn/commodore/pull/528


## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
