### PR TITLE
Manage component README

### DIFF
--- a/moduleroot/README.md.erb
+++ b/moduleroot/README.md.erb
@@ -1,0 +1,27 @@
+# Commodore Component: <%= @configs['componentName'] %>
+
+This is a [Commodore][commodore] Component for <%= @configs['componentName'] %>.
+
+This repository is part of Project Syn.
+For documentation on Project Syn and this component, see https://syn.tools.
+
+## Documentation
+
+The rendered documentation for this component is available on the [Commodore Components Hub](https://hub.syn.tools/<%= @metadata[:module_name].delete_prefix('component-') %>).
+
+Documentation for this component is written using [Asciidoc][asciidoc] and [Antora][antora].
+It is located in the [docs/](docs) folder.
+The [Divio documentation structure](https://documentation.divio.com/) is used to organize its content.
+
+Run the `make docs-serve` command in the root of the project, and then browse to http://localhost:2020 to see a preview of the current state of the documentation.
+
+After writing the documentation, please use the `make docs-vale` command and correct any warnings raised by the tool.
+
+## Contributing and license
+
+This library is licensed under [BSD-3-Clause](LICENSE).
+For information about how to contribute see [CONTRIBUTING](CONTRIBUTING.md).
+
+[commodore]: https://syn.tools/commodore/
+[asciidoc]: https://asciidoctor.org/
+[antora]: https://antora.org/

--- a/moduleroot/docs/antora.yml.erb
+++ b/moduleroot/docs/antora.yml.erb
@@ -1,11 +1,13 @@
 #
 # File managed by ModuleSync - Do Not Edit
 #
-# The name and title can be customized in `.sync.yml` with `'docs/antora.yml'.title`, `'docs/antora.yml'.name`
+# The title can be customized in `.sync.yml` with `:global.componentName`
+# The name is generated from the component's GitHub repository name, with the
+# `component-` prefix removed.
 #
 
-name: <%= @configs['name'] %>
-title: <%= @configs['title'] %>
+name: <%= @metadata[:module_name].delete_prefix('component-') %>
+title: <%= @configs['componentName'] %>
 version: <%= @configs['version'] %>
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
This PR adds a template for the component README.md.

Addititionally, the PR also changes how the contents of `docs/antora.yml` are managed: we no longer need the parameters `name` and `title` for `docs/antora.yml` in the components' `.sync.yml`, instead we construct the component name ("slug" in the cookiecutter component template) from the GitHub repo name, and use `:global.componentName` as the component title ("name" in the cookiecutter template).

Commodore PR: https://github.com/projectsyn/commodore/pull/529

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
