### PR TITLE
Add `/dependencies` to component `.gitignore`

### DIFF
--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -6,6 +6,7 @@
 
 # Commodore
 /.cache
+/dependencies
 /helmcharts
 /manifests
 /vendor


### PR DESCRIPTION
With the new rooted gitignore entries, we need to add `/dependencies` as `component compile` generates that directory for most components.

Follow-up to #79

Commodore PR: https://github.com/projectsyn/commodore/pull/533

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
