### PR TITLE
Add `lint_kubent` make targets to check for deprecated API versions

### DIFF
--- a/moduleroot/Makefile.erb
+++ b/moduleroot/Makefile.erb
@@ -24,7 +24,7 @@ help: ## Show this help
 all: lint
 
 .PHONY: lint
-lint: lint_jsonnet lint_yaml lint_adoc ## All-in-one linting
+lint: lint_jsonnet lint_yaml lint_adoc<% if @configs['feature_goldenTests'] %> lint_kubent<% end %> ## All-in-one linting
 
 .PHONY: lint_jsonnet
 lint_jsonnet: $(JSONNET_FILES) ## Lint jsonnet files
@@ -38,6 +38,12 @@ lint_yaml: ## Lint yaml files
 lint_adoc: ## Lint documentation
 	$(VALE_CMD) $(VALE_ARGS)
 
+<%- if @configs['feature_goldenTests'] -%>
+.PHONY: lint_kubent
+lint_kubent: ## Lint deprecated Kubernetes API versions
+	$(KUBENT_DOCKER) $(KUBENT_ARGS) -f $(KUBENT_FILES)
+
+<%- end -%>
 .PHONY: format
 format: format_jsonnet ## All-in-one formatting
 
@@ -84,6 +90,10 @@ golden-diff-all: $(test_instances) ## Run golden-diff for all instances. Note: t
 .PHONY: gen-golden-all
 gen-golden-all: recursive_target=gen-golden
 gen-golden-all: $(test_instances) ## Run gen-golden for all instances. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
+
+.PHONY: lint_kubent_all
+lint_kubent_all: recursive_target=lint_kubent
+lint_kubent_all: $(test_instances) ## Lint deprecated Kubernetes API versions for all golden test instances. Will exit on first error. Note: this doesn't work when running make with multiple parallel jobs (-j != 1).
 
 .PHONY: $(test_instances)
 $(test_instances):

--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -40,6 +40,16 @@ COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) docker.io/projects
 COMPILE_CMD    ?= $(COMMODORE_CMD) component compile . $(commodore_args)
 JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb docker.io/projectsyn/commodore:latest install
 
+<%- if @configs['feature_goldenTests'] -%>
+GOLDEN_FILES    ?= $(shell find tests/golden/$(instance) -type f)
+
+KUBENT_FILES    ?= $(shell echo "$(GOLDEN_FILES)" | sed 's/ /,/g')
+KUBENT_ARGS     ?= -c=false --helm2=false --helm3=false -e
+# Use our own kubent image until the upstream image is available
+KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
+KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
+
+<%- end -%>
 instance ?= defaults
 <%- if @configs['feature_goldenTests'] && !@configs['testMatrix'].empty? && !@configs['testMatrix']['entries'].empty? -%>
 test_instances =<%- @configs['testMatrix']['entries'].each do |entry| %> tests/<%= entry %>.yml<% end %>


### PR DESCRIPTION
The `lint_kubent` target runs `kubent` on a single golden test instance, defaulting to instance `defaults`. The commit also adds a target `lint_kubent_all` which will run `kubent` for all targets separately.

We don't run `kubent` over all golden tests simultaneously because the tool doesn't support linting multiple Kubernetes objects with the same name and namespace in a single run.

The commit ensures that the `kubent` lint targets are only added for components which are configured with golden tests enabled.

Commodore PR: https://github.com/projectsyn/commodore/pull/544

Resolves #47 

## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
