### PR TITLE
Hard-code component name in `Makefile.vars.mk`

### DIFF
--- a/moduleroot/Makefile.vars.mk.erb
+++ b/moduleroot/Makefile.vars.mk.erb
@@ -4,14 +4,14 @@
 # Additional Makefiles can be added to `.sync.yml` in 'Makefile.includes'
 #
 
-# Commodore takes the root dir name as the component name
-COMPONENT_NAME ?= $(shell basename ${PWD} | sed s/component-//)
+# The component name is hard-coded from the template
+COMPONENT_NAME ?= <%= @metadata[:module_name].delete_prefix('component-') %>
 
 git_dir         ?= $(shell git rev-parse --git-common-dir)
 compiled_path   ?= compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)
 root_volume     ?= -v "$${PWD}:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
-commodore_args  ?= --search-paths ./dependencies --search-paths .
+commodore_args  ?= --search-paths ./dependencies --search-paths . -n $(COMPONENT_NAME)
 
 ifneq "$(git_dir)" ".git"
 	git_volume        ?= -v "$(git_dir):$(git_dir):ro"


### PR DESCRIPTION
This should reduce the amount of patching required when setting up a component in a subdirectory from the template.

Commodore PR: https://github.com/projectsyn/commodore/pull/588


## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
