### PR TITLE
Add template for `.cruft.json`

### DIFF
--- a/moduleroot/.cruft.json.erb
+++ b/moduleroot/.cruft.json.erb
@@ -1,0 +1,42 @@
+<%-
+@cname = @metadata[:module_name].delete_prefix('component-')
+@matrix = @configs['testMatrix']
+if !@matrix.empty? then
+  @add_matrix = "y"
+  @test_cases = @matrix['entries'].join(" ")
+else
+  @add_matrix = "n"
+  @test_cases = "defaults"
+end
+if @configs['feature_goldenTests'] then
+  @add_golden = "y"
+else
+  @add_golden = "n"
+end
+if @configs['feature_goUnitTests'] then
+  @add_go_unit = "y"
+else
+  @add_go_unit = "n"
+end
+-%>
+{
+  "template": "https://github.com/projectsyn/commodore-component-template.git",
+  "commit": "e6c4fd69190db1ad12e941d578b9423d0e2f993c",
+  "checkout": "main",
+  "context": {
+    "cookiecutter": {
+      "name": "<%= @configs['componentName'] %>",
+      "slug": "<%= @cname %>",
+      "parameter_key": "<%= @cname.gsub('-', '_') %>",
+      "test_cases": "<%= @test_cases %>",
+      "add_golden": "<%= @add_golden %>",
+      "add_matrix": "<%= @add_matrix %>",
+      "add_go_unit": "<%= @add_go_unit %>",
+      "github_owner": "<%= @configs[:namespace] %>",
+      "github_name": "<%= @metadata[:module_name] %>",
+      "github_url": "https://github.com/<%= @configs[:namespace] %>/<%= @metadata[:module_name] %>",
+      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+    }
+  },
+  "directory": null
+}


### PR DESCRIPTION
Add a `.cruft.json` to all managed components, so we can migrate component template sync to `commodore component sync` based on the Cookiecutter template in https://github.com/projectsyn/commodore-component-template/



## Checklist

- [x] The [component template][commodore] has a PR open that syncs the changes with this one. -- not necessary
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

[commodore]: https://github.com/projectsyn/commodore
<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
